### PR TITLE
Specifying the redirect url

### DIFF
--- a/lib/login-checker.js
+++ b/lib/login-checker.js
@@ -87,7 +87,7 @@ module.exports = function (options) {
     }
 
     var ticket = getTicketIfPresentInUrl(req.url);
-    var originUrl = stripTicketFromUrl(fullUrl);
+    var originUrl = options.service || stripTicketFromUrl(fullUrl);
 
     if (ticket) {
       if (!validateTicket(ticket)) {


### PR DESCRIPTION
If the service parameter of the options hash is provided use it instead of origin as the redirect url.